### PR TITLE
fix bug SignFlowFileDownloadUrlResp

### DIFF
--- a/easy-esign-struct/src/main/java/io/github/easy/esign/struct/sign/resp/SignFlowFileDownloadUrlResp.java
+++ b/easy-esign-struct/src/main/java/io/github/easy/esign/struct/sign/resp/SignFlowFileDownloadUrlResp.java
@@ -40,7 +40,7 @@ public class SignFlowFileDownloadUrlResp {
         //文件ID
         String fileId;
         //文件名称
-        String filename;
+        String fileName;
         //文件下载链接（有效期为60分钟，过期后可以重新调用接口获取新的下载地址）
         String downloadUrl;
     }


### PR DESCRIPTION
下载已签署文件及附属材料接口中fileInfo对象的fileName字段错误