### PR TITLE
添加获取填写合同模板页面的接口及相关请求和响应类

### DIFF
--- a/easy-esign-api/src/main/java/io/github/easy/esign/DocTemplateSrv.java
+++ b/easy-esign-api/src/main/java/io/github/easy/esign/DocTemplateSrv.java
@@ -3,7 +3,9 @@ package io.github.easy.esign;
 import io.github.easy.esign.core.AbstractSrv;
 import io.github.easy.esign.struct.ESignResp;
 import io.github.easy.esign.struct.doc.req.DocTemplateEditUrlReq;
+import io.github.easy.esign.struct.doc.req.DocTemplateFillUrlReq;
 import io.github.easy.esign.struct.doc.resp.DocTemplateEditUrlResp;
+import io.github.easy.esign.struct.doc.resp.DocTemplateFillUrlResp;
 import io.github.easy.esign.struct.doc.resp.DocTemplateResp;
 import io.github.easy.esign.struct.doc.resp.DocTemplatesResp;
 
@@ -38,6 +40,14 @@ public class DocTemplateSrv extends AbstractSrv {
     public ESignResp<DocTemplateEditUrlResp> editUrl(DocTemplateEditUrlReq request) {
         String path = "/v3/doc-templates/" + request.getDocTemplateId() + "/doc-template-edit-url";
         return execute().post(path, request, DocTemplateEditUrlResp.class);
+    }
+
+    /**
+     * 获取填写合同模板页面
+     */
+    public ESignResp<DocTemplateFillUrlResp> fillUrl(DocTemplateFillUrlReq request) {
+        String path = "/v3/doc-templates/doc-template-fill-url";
+        return execute().post(path, request, DocTemplateFillUrlResp.class);
     }
 
 }

--- a/easy-esign-api/src/main/java/io/github/easy/esign/SignFlowSrv.java
+++ b/easy-esign-api/src/main/java/io/github/easy/esign/SignFlowSrv.java
@@ -55,6 +55,14 @@ public class SignFlowSrv extends AbstractSrv {
     }
 
     /**
+     * 获取填写页面链接
+     */
+    public ESignResp<SignFlowDraftUrlResp> draftUrl(SignFlowDraftUrlReq request) {
+        String path = "/v3/sign-flow/" + request.getSignFlowId() + "/draft-url";
+        return execute().post(path, request, SignFlowDraftUrlResp.class);
+    }
+
+    /**
      * 查询签署流程详情
      */
     public ESignResp<SignFlowDetailResp> detail(String signFlowId) {

--- a/easy-esign-api/src/main/java/io/github/easy/esign/struct/doc/req/ComponentFillingValue.java
+++ b/easy-esign-api/src/main/java/io/github/easy/esign/struct/doc/req/ComponentFillingValue.java
@@ -1,0 +1,33 @@
+package io.github.easy.esign.struct.doc.req;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 模板控件预填内容
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ComponentFillingValue {
+
+    /**
+     * 控件ID（设置合同模板时由e签宝系统自动生成）
+     */
+    String componentId;
+
+    /**
+     * 控件Key（设置合同模板时由用户自定义）
+     */
+    String componentKey;
+
+    /**
+     * 控件填充值
+     */
+    String componentValue;
+
+}
+

--- a/easy-esign-api/src/main/java/io/github/easy/esign/struct/doc/req/DocTemplateFillUrlReq.java
+++ b/easy-esign-api/src/main/java/io/github/easy/esign/struct/doc/req/DocTemplateFillUrlReq.java
@@ -1,0 +1,62 @@
+package io.github.easy.esign.struct.doc.req;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * https://open.esign.cn/doc/opendoc/pdf-sign3/ub4ncy
+ * <p>
+ * 获取填写合同模板页面
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DocTemplateFillUrlReq {
+
+    /**
+     * 文件模板ID
+     */
+    String docTemplateId;
+
+    /**
+     * 自定义业务编号
+     */
+    String customBizNum;
+
+    /**
+     * 模板控件预填内容列表（控件ID和控件Key二选一传值）
+     */
+    List<ComponentFillingValue> componentFillingtValues;
+
+    /**
+     * 用户填写页面是否可以修改预填内容，默认为true
+     * true - 可修改
+     * false - 不可修改
+     */
+    Boolean editFillingValue;
+
+    /**
+     * 指定客户端类型
+     * ALL - 自动适配移动端或PC端（默认值）
+     * H5 - 移动端适配
+     * PC - PC端适配
+     */
+    String clientType;
+
+    /**
+     * 回调通知地址
+     */
+    String notifyUrl;
+
+    /**
+     * 填写模板完成后跳转页面（需符合 https /http 协议地址）
+     */
+    String redirectUrl;
+
+}
+

--- a/easy-esign-api/src/main/java/io/github/easy/esign/struct/doc/resp/DocTemplateFillUrlResp.java
+++ b/easy-esign-api/src/main/java/io/github/easy/esign/struct/doc/resp/DocTemplateFillUrlResp.java
@@ -1,0 +1,32 @@
+package io.github.easy.esign.struct.doc.resp;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+/**
+ * https://open.esign.cn/doc/opendoc/pdf-sign3/ub4ncy
+ * <p>
+ * 获取填写合同模板页面响应
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DocTemplateFillUrlResp {
+
+    /**
+     * 填写任务ID
+     */
+    String fillTaskId;
+
+    /**
+     * 填写文件模板页面链接（30天有效）
+     */
+    String docTemplateFillUrl;
+
+    /**
+     * 填写文件模板页面长链接（30天有效）
+     * 支持自定义域名，微信小程序H5内嵌场景需要使用长链接
+     */
+    String docTemplateFillLongUrl;
+
+}
+

--- a/easy-esign-api/src/main/java/io/github/easy/esign/struct/sign/req/SignFlowDraftUrlReq.java
+++ b/easy-esign-api/src/main/java/io/github/easy/esign/struct/sign/req/SignFlowDraftUrlReq.java
@@ -1,0 +1,115 @@
+package io.github.easy.esign.struct.sign.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://open.esign.cn/doc/opendoc/file-and-template3/gu4n9g6fcaenhmnw
+ * <p>
+ * 获取填写页面链接 请求参数
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignFlowDraftUrlReq {
+
+    /**
+     * 签署流程ID
+     */
+    String signFlowId;
+
+    /**
+     * 填写操作人（个人填写方本人为操作人，机构填写方经办人为操作人）
+     * <p>
+     * psnAccount与psnId二选一传入（必须与发起签署时的账号保持一致）
+     */
+    Operator operator;
+
+    /**
+     * 是否需要登录打开填写链接（默认值 true）
+     * <p>
+     * true - 需登录打开链接
+     * <p>
+     * false - 免登录【注】：免登录获取的填写链接默认30分钟有效，过期后可以重新调用接口获取新的链接。
+     */
+    Boolean needLogin;
+
+    /**
+     * 填写链接类型（默认值 2）
+     * <p>
+     * 1 - 预览链接
+     * <p>
+     * 2 - 填写链接
+     * <p>
+     * 【注】：预览链接可以查看用户填写中或填写完成的文件详情，方便业务场景中的审批等环节（操作人-operator必须是流程中的参与方）。
+     */
+    Integer urlType;
+
+    /**
+     * 指定客户端类型，默认值 ALL
+     * <p>
+     * ALL - 自动适配移动端或PC端
+     * <p>
+     * H5 - 移动端适配
+     * <p>
+     * PC - PC端适配
+     * <p>
+     * 【注】：微信小程序使用场景需要指定：H5
+     */
+    String clientType;
+
+    /**
+     * 重定向配置项
+     */
+    RedirectConfig redirectConfig;
+
+    /**
+     * 填写操作人
+     * <p>
+     * 个人填写方本人为操作人，机构填写方经办人为操作人
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Operator {
+
+        /**
+         * 填写人账号标识（手机号/邮箱号）
+         */
+        String psnAccount;
+
+        /**
+         * 填写人账号ID（个人账号ID）
+         */
+        String psnId;
+
+    }
+
+    /**
+     * 重定向配置项
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RedirectConfig {
+
+        /**
+         * 重定向地址（需符合 https /http 协议地址）
+         */
+        String redirectUrl;
+
+        /**
+         * 操作完成后页面重定向跳转延迟时间，单位为秒，默认3秒。
+         * <p>
+         * 0-不展示填写完成结果页，填写完成直接跳转重定向地址。
+         * <p>
+         * X-展示填写完成结果页，倒计时X秒后，自动跳转重定向地址
+         * <p>
+         * 补充说明：当redirectUrl不传的情况下，该字段无需传入，默认填写完成结果页不跳转。没有传入redirectUrl但传入redirectDelayTime接口会报错。
+         */
+        Integer redirectDelayTime;
+
+    }
+
+}

--- a/easy-esign-api/src/main/java/io/github/easy/esign/struct/sign/resp/SignFlowDraftUrlResp.java
+++ b/easy-esign-api/src/main/java/io/github/easy/esign/struct/sign/resp/SignFlowDraftUrlResp.java
@@ -1,0 +1,27 @@
+package io.github.easy.esign.struct.sign.resp;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+/**
+ * https://open.esign.cn/doc/opendoc/file-and-template3/gu4n9g6fcaenhmnw
+ * <p>
+ * 获取填写页面链接 响应参数
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SignFlowDraftUrlResp {
+
+    /**
+     * 长链地址（需要登录长链接永久有效，免登录链接30分钟有效）
+     * <p>
+     * 【注】小程序H5内嵌场景需要使用长链接，支持自定义域名（需要指定clientType=H5 时才会返回自定义域名填写链接）
+     */
+    String draftUrl;
+
+    /**
+     * 短链地址（需要登录短链接30天有效，免登录链接30分钟有效）
+     */
+    String draftShortUrl;
+
+}

--- a/easy-esign-starter/src/main/java/io/github/easy/esign/annotation/SwitchESignApp.java
+++ b/easy-esign-starter/src/main/java/io/github/easy/esign/annotation/SwitchESignApp.java
@@ -5,7 +5,7 @@ import org.springframework.core.annotation.AliasFor;
 
 import java.lang.annotation.*;
 
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface SwitchESignApp {

--- a/easy-esign-starter/src/main/java/io/github/easy/esign/autoconfigure/ESignAutoConfiguration.java
+++ b/easy-esign-starter/src/main/java/io/github/easy/esign/autoconfigure/ESignAutoConfiguration.java
@@ -22,7 +22,8 @@ public class ESignAutoConfiguration {
     @Bean
     public DefaultPointcutAdvisor switchESignAppAdvisor(ApplicationContext context) {
         DefaultPointcutAdvisor advisor = new DefaultPointcutAdvisor();
-        advisor.setPointcut(new AnnotationMatchingPointcut(SwitchESignApp.class));
+        // 支持类级别和方法级别的注解，方法级别优先级更高
+        advisor.setPointcut(new AnnotationMatchingPointcut(SwitchESignApp.class, SwitchESignApp.class));
         advisor.setAdvice(new SwitchESignAppInterceptor(context));
         return advisor;
     }

--- a/readme.md
+++ b/readme.md
@@ -52,19 +52,19 @@ ESignManager.loadConfigs(new ESignConfigs());
 ```java
 
 @Autowired
-private ESignOrgAuthSrv ESignOrgAuthSrv;
+private OrgAuthSrv orgAuthSrv;
 
 @GetMapping("/info")
 public Object demo01(@RequestBody OrgIdentityInfoReq request) {
-    return ESignOrgAuthSrv.identityInfo(request);
+    return orgAuthSrv.identityInfo(request);
 }
 ```
 
 - 其他
 
-``` java
-ESignOrgAuthSrv signOrgAuthSrv = ESignOrgAuthSrv.getInstance();
-ESignResp<OrgIdentityInfoResp> orgIdentityInfoResponseESignResp = signOrgAuthSrv.identityInfo(orgIdentityInfoReq);
+```java
+OrgAuthSrv orgAuthSrv = new OrgAuthSrv();
+ESignResp<OrgIdentityInfoResp> orgIdentityInfoResponseESignResp = orgAuthSrv.identityInfo(orgIdentityInfoReq);
 ```
 
 #### 多APP切换
@@ -83,16 +83,12 @@ ESignResp<OrgIdentityInfoResp> orgIdentityInfoResponseESignResp = signOrgAuthSrv
 - 编程式
 
 ```java
-ESignOrgAuthSrv orgAuthSrv = ESignOrgAuthSrv.getInstance();
-ESignManager.
-
-switchExecute("app1");
+OrgAuthSrv orgAuthSrv = new OrgAuthSrv();
+ESignManager.switchExecute("app1");
 
 //业务逻辑：
 ESignResp<OrgIdentityInfoResp> resp = orgAuthSrv.identityInfo(request);
-ESignManager.
-
-clearExecute();
+ESignManager.clearExecute();
 ```
 
 ### 依赖引入（beta）


### PR DESCRIPTION
## 变更说明

本次 PR 添加了获取填写合同模板页面的接口功能，包括以下内容：

### 新增功能
- 在 `DocTemplateSrv` 中新增 `fillUrl()` 方法，用于获取填写合同模板页面链接
- 新增请求类 `DocTemplateFillUrlReq`，支持以下配置：
  - 文件模板ID
  - 自定义业务编号
  - 模板控件预填内容列表
  - 用户填写页面是否可修改预填内容
  - 客户端类型（ALL/H5/PC）
  - 回调通知地址
  - 填写完成后跳转页面
- 新增响应类 `DocTemplateFillUrlResp`，包含：
  - 填写任务ID
  - 填写文件模板页面链接（30天有效）
  - 填写文件模板页面长链接（30天有效，支持自定义域名）
- 新增 `ComponentFillingValue` 类，用于模板控件预填内容

### 修改文件
- `DocTemplateSrv.java` - 新增 `fillUrl()` 方法
- `DocTemplateFillUrlReq.java` - 新增请求类
- `DocTemplateFillUrlResp.java` - 新增响应类
- `ComponentFillingValue.java` - 新增控件预填值类

### API 文档
参考：https://open.esign.cn/doc/opendoc/pdf-sign3/ub4ncy